### PR TITLE
Disable SSR in development to fix npm-link

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -108,6 +108,8 @@ App.getInitialProps = async () => {
 // - https://github.com/vercel/next.js/issues/5463
 // - https://github.com/vercel/next.js/issues/5638
 // - https://github.com/vercel/next.js/issues/706
+//
+// eslint-disable-next-line import/no-mutable-exports
 let NextApp = App
 if (process.env.NODE_ENV !== 'production') {
   NextApp = (...args) => {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -101,4 +101,20 @@ App.getInitialProps = async () => {
   }
 }
 
-export default App
+// Dangerously disabling Next.js SSR on development environment to speed-up
+// development with linked packages (to outside the project directory)
+//
+// Related issues on GitHub:
+// - https://github.com/vercel/next.js/issues/5463
+// - https://github.com/vercel/next.js/issues/5638
+// - https://github.com/vercel/next.js/issues/706
+let NextApp = App
+if (process.env.NODE_ENV !== 'production') {
+  NextApp = (...args) => {
+    if (typeof window == 'undefined') return null
+    return App.apply(this, args)
+  }
+  NextApp.getInitialProps = App.getInitialProps
+}
+
+export default NextApp


### PR DESCRIPTION
Dangerously disabling Next.js SSR on development environment to speed-up development with linked packages (to outside the project directory).

This should be safe because every PR is deployed on Vercel where SSR could be tested before going to production server.