### PR TITLE
Add global loading reporting

### DIFF
--- a/main/index.jsx
+++ b/main/index.jsx
@@ -6,14 +6,14 @@ import Head from './head'
 import Layout from 'modules/layout'
 import { useInitStore, StoreProvider } from 'store'
 
-const Main = ({ children, initialState }) => {
+const Main = ({ children, initialState, loading }) => {
   const store = useInitStore(initialState)
 
   return (
     <StoreProvider store={store}>
       <DesignProvider>
         <Head />
-        <Layout>{children}</Layout>
+        <Layout loading={loading}>{children}</Layout>
       </DesignProvider>
     </StoreProvider>
   )

--- a/modules/layout/index.jsx
+++ b/modules/layout/index.jsx
@@ -1,12 +1,14 @@
 import React from 'react'
+import { LoadingBar } from '@oacore/design'
 
 import Container from './container'
 import AppBar from './app-bar'
 import styles from './styles.module.css'
 import Footer from './footer'
 
-const Layout = ({ children }) => (
+const Layout = ({ children, loading }) => (
   <Container>
+    {loading && <LoadingBar fixed />}
     <AppBar />
     <main className={styles.main}>{children}</main>
     <Footer />

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import NextApp from 'next/app'
+import React, { Component as ReactComponent } from 'react'
 
 // TODO: Move to map component once
 //       https://github.com/vercel/next.js/issues/12079 is solved
@@ -21,7 +20,7 @@ process.on('uncaughtException', (err) => {
   Sentry.captureException(err)
 })
 
-class App extends NextApp {
+class ErrorBoundary extends ReactComponent {
   // eslint-disable-next-line class-methods-use-this
   componentDidCatch(error, errorInfo) {
     Sentry.withScope((scope) => {
@@ -34,14 +33,19 @@ class App extends NextApp {
   }
 
   render() {
-    const { Component, pageProps, statistics } = this.props
-
-    return (
-      <Main initialState={{ statistics }}>
-        <Component {...pageProps} />
-      </Main>
-    )
+    const { children } = this.props
+    return children
   }
+}
+
+const App = ({ Component: PageComponent, pageProps, statistics }) => {
+  return (
+    <ErrorBoundary>
+      <Main initialState={{ statistics }}>
+        <PageComponent {...pageProps} />
+      </Main>
+    </ErrorBoundary>
+  )
 }
 
 let statistics = {

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -36,10 +36,9 @@ class App extends NextApp {
   render() {
     const { Component, pageProps, statistics } = this.props
 
-    const { initialState, ...restPageProps } = pageProps || {}
     return (
-      <Main initialState={{ ...initialState, statistics }}>
-        <Component {...restPageProps} />
+      <Main initialState={{ statistics }}>
+        <Component {...pageProps} />
       </Main>
     )
   }


### PR DESCRIPTION
Adds fixed LoadingBar to the top of the page that appears based on the router state: from the `routeChangeStart` to either `routeChangeComplete` or `routeChangeError`.