### PR TITLE
Modify redirectToProviders for dynamic href using dataProviderId

### DIFF
--- a/modules/dropdown/index.jsx
+++ b/modules/dropdown/index.jsx
@@ -48,7 +48,7 @@ const DropDown = ({
   }
 
   const redirectToProviders = () => {
-    window.location.href = metadata.hrefDataProvider
+    window.location.href = `//core.ac.uk/data-providers/${dataProviderId}`
   }
 
   const getLogoLink = () => {


### PR DESCRIPTION
Update the redirectToProviders function to use the correct dataProviderId. 

Fixes https://kmi-ou.atlassian.net/browse/CORE-5592